### PR TITLE
We specifically only want nil here, not blank

### DIFF
--- a/lib/live_fixtures/export/fixture.rb
+++ b/lib/live_fixtures/export/fixture.rb
@@ -50,7 +50,7 @@ module LiveFixtures::Export::Fixture
     if attribute_type.is_a?(ActiveRecord::Type::Serialized)
       value = attribute_type.type_cast_for_database(value) unless value.is_a?(String)
 
-      "#{name}: |-\n#{value.to_s.indent(4)}" unless value.blank?
+      "#{name}: |-\n#{value.to_s.indent(4)}" unless value.nil?
     elsif value.is_a? LiveFixtures::Export::Reference
       "#{value.name}: #{yml_value(value)}"
     else


### PR DESCRIPTION
#### Context:

This was a change that was missed in #11 .

We don't want to omit the whole attribute if the value is blank, then we wouldn't be able to serialize things like `''` or `[]` or `{}` or `false`. We want to omit it only if it's nil (returned here: https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/type/serialized.rb#L25)