### PR TITLE
Importer fails on missing label instead of missing table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.1] - 2017-??-??
-### Fixed
+### Breaking changes
  - For models with serialized attributes (for storing a ruby object or json blob in a single column, for example), live_fixtures will now use the coder specified in the model definition to dump the value to a string, rather than serializing it to yaml. #10, #11
+ - The importer no longer raises an ArgumentError when a yml file for a table listed in `insert_order` cannot be found. Instead, we raise an error if we attempt to replace a label with an ID and cannot find the label yet. This should allow more versatile insert_order lists and also do a better job of ensuring integrity.
 
 ### Added
  - Enhanced documentation #1, #12

--- a/README.md
+++ b/README.md
@@ -157,7 +157,21 @@ If we pass `:user` as references, LiveFixtures will replace the foreign key with
 
 When we import these fixtures using the correct `insert_order` (`['users', 'posts']`), the newly imported post will belong to the newly imported user, no matter what their new ids are.
 
-Currently, this only works for associations that return a single record (:belongs_to and :has_one).
+Currently, this works for `belongs_to` and `has_and_belongs_to_many` associations.
+
+For `has_and_belongs_to_many` associations, there is a good deal of flexibility. The attribute name should be the name of the association (probably plural). The attribute value should be a list of the associated records. This list can be either an array or a comma separated list. If the list is a list of labels, the labels will be replaced on import. If it is a list of IDs, the IDs will be inserted as they are listed.
+
+
+    # In dogwalkers.yml
+    dogwalkers_15:
+      dogs: '1,3'
+
+    dogwalkers_16:
+      dogs:
+        - dogs_12
+        - dogs_14
+
+The above fixture, when imported would add both Dogwalker fixtures to the `dogwalkers` table, and it would also populate the join table (`dogwalkers_dogs`, or whatever is specified by the association). All the labels will be replaced with their newly assigned IDs, but the IDs of dogwalkers_15's dogs will remain as 1 and 3.
 
 ### Templates
 

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -18,7 +18,7 @@ class LiveFixtures::Import
     end
     @table_names = insert_order.select {|table_name| @table_names.include? table_name}
     if @table_names.size < insert_order.size
-      raise ArgumentError, "table(s) mentioned in `insert_order` which has no yml file to import: #{insert_order - @table_names}"
+      warn "table(s) mentioned in `insert_order` which has no yml file to import: #{insert_order - @table_names}"
     end
     @label_to_id = {}
   end

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -6,7 +6,6 @@ class LiveFixtures::Import
   # the order in which to import them. The order should ensure fixtures
   # containing references to another fixture are imported AFTER the referenced
   # fixture.
-  # @raise [ArgumentError] raises an argument error if not every element in the insert_order has a corresponding yml file.
   # @param root_path [String] path to the directory containing the yml files to import.
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
   # @return [LiveFixtures::Import] an importer

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -77,6 +77,14 @@ class LiveFixtures::Import
 
     private
 
+    # Uses the underlying map of labels to return the referenced model's newly
+    # assigned ID.
+    # @param label_to_fetch [String] the label of the referenced model.
+    # @return [Integer] the newly assigned ID of the referenced model.
+    def fetch_id_for_label(label_to_fetch)
+      @label_to_id[label_to_fetch]
+    end
+
     def inheritance_column_name
       @inheritance_column_name ||= model_class && model_class.inheritance_column
     end

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -66,7 +66,11 @@ class LiveFixtures::Import
       join_table_rows.each do |table_name, rows|
         rows.each do |targets:, association:, label:|
           targets.each do |target|
-            assoc_fk = @label_to_id[target] || target
+            assoc_fk = if target.starts_with?(association.table_name)
+              @label_to_id[target]
+            else
+              target
+            end
             row = { association.foreign_key             => @label_to_id[label],
                     association.association_foreign_key => assoc_fk }
             yield [table_name, NO_LABEL, row]

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -118,6 +118,7 @@ class LiveFixtures::Import
       fk_name = (association.options[:foreign_key] || "#{association.name}_id").to_s
 
       # Do not replace association name with association foreign key if they are named the same
+      # TODO...this is kind of buggy, as this early return skips the label replacement.
       return if association.name.to_s == fk_name
 
       value = row.delete(association.name.to_s)

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -71,7 +71,7 @@ class LiveFixtures::Import
             # dogs: 12, 32, 144 instead of dogs: dogs_12, dogs_32, dogs_144
             # I'm not sure why we decided to do this.
             assoc_fk = if is_label_for_table?(target, association.table_name)
-              @label_to_id[target]
+              fetch_id_for_label(target)
             else
               target
             end

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'active_record/fixtures'
 
 class LiveFixtures::Import

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -1,6 +1,7 @@
 require 'active_record/fixtures'
 
 class LiveFixtures::Import
+  LiveFixtures::MissingReferenceError = Class.new(KeyError)
   class Fixtures
     delegate :model_class, :table_name, :fixtures, to: :ar_fixtures
     # ActiveRecord::FixtureSet for delegation

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -1,6 +1,9 @@
 require 'active_record/fixtures'
 
 class LiveFixtures::Import
+  # A labeled reference was not found.
+  # Maybe the referenced model was not exported, or the insert order attempted
+  # to import the reference before the referenced model?
   LiveFixtures::MissingReferenceError = Class.new(KeyError)
   class Fixtures
     delegate :model_class, :table_name, :fixtures, to: :ar_fixtures

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -66,7 +66,10 @@ class LiveFixtures::Import
       join_table_rows.each do |table_name, rows|
         rows.each do |targets:, association:, label:|
           targets.each do |target|
-            assoc_fk = if target.starts_with?(association.table_name)
+            # This song and dance is so we can specify HABTM like so:
+            # dogs: 12, 32, 144 instead of dogs: dogs_12, dogs_32, dogs_144
+            # I'm not sure why we decided to do this.
+            assoc_fk = if is_label_for_table?(target, association.table_name)
               @label_to_id[target]
             else
               target

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -123,7 +123,7 @@ class LiveFixtures::Import
         row[association.foreign_type] = $1
       end
 
-      row[fk_name] = @label_to_id[value]
+      row[fk_name] = fetch_id_for_label(value)
     end
 
     private :ar_fixtures

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -83,10 +83,18 @@ class LiveFixtures::Import
 
     # Uses the underlying map of labels to return the referenced model's newly
     # assigned ID.
+    # @raise [LiveFixtures::MissingReferenceError] if the label isn't found.
     # @param label_to_fetch [String] the label of the referenced model.
     # @return [Integer] the newly assigned ID of the referenced model.
     def fetch_id_for_label(label_to_fetch)
-      @label_to_id[label_to_fetch]
+      @label_to_id.fetch(label_to_fetch)
+    rescue KeyError
+      raise LiveFixtures::MissingReferenceError, <<-ERROR.squish
+      Unable to find ID for model referenced by label #{label_to_fetch} while
+      importing #{model_class} from #{table_name}.yml. Perhaps it isn't included
+      in these fixtures or it is too late in the insert_order and has not yet
+      been imported.
+      ERROR
     end
 
     def inheritance_column_name

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -101,6 +101,17 @@ class LiveFixtures::Import
       ERROR
     end
 
+    # Checks if the string looks like a label referencing the specified table.
+    # @param label_to_check [String] the string that might be a label.
+    # @param table_name [String] the table the label might reference.
+    # @return [Boolean] whether the string is a label for the table.
+    # @see LiveFixtures::Export::Reference
+    # @see LiveFixtures::Export::Fixture#yml_value
+    def is_label_for_table?(label_to_check, table_name)
+      label_prefix = table_name + "_"
+      label_to_check.starts_with? label_prefix
+    end
+
     def inheritance_column_name
       @inheritance_column_name ||= model_class && model_class.inheritance_column
     end

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -74,7 +74,8 @@ class LiveFixtures::Import
             else
               target
             end
-            row = { association.foreign_key             => @label_to_id[label],
+            binding.pry
+            row = { association.foreign_key             => fetch_id_for_label(label),
                     association.association_foreign_key => assoc_fk }
             yield [table_name, NO_LABEL, row]
           end

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -74,7 +74,6 @@ class LiveFixtures::Import
             else
               target
             end
-            binding.pry
             row = { association.foreign_key             => fetch_id_for_label(label),
                     association.association_foreign_key => assoc_fk }
             yield [table_name, NO_LABEL, row]

--- a/live_fixtures.gemspec
+++ b/live_fixtures.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "temping", "~> 3.0"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "reek"

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -106,7 +106,8 @@ describe LiveFixtures::Import::Fixtures do
         {
             table_label => 1941,
             visitor_one_label => 1942,
-            visitor_two_label => 1982
+            visitor_two_label => 1982,
+            cafe_label => 2016
         }
       end
       let(:join_table_name) { 'dogs_tables' }

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -50,6 +50,33 @@ describe LiveFixtures::Import::Fixtures do
     end
   end
 
+  describe '#is_label_for_table?(label_to_check, table_name)' do
+    before do
+      allow(ActiveRecord::FixtureSet).
+        to receive(:new).
+        with(any_args).
+        and_return(ar_fixtureset_double)
+    end
+    let(:ar_fixtureset_double) { instance_double 'ActiveRecord::FixtureSet' }
+    let(:table_name) { 'trogolodytes' }
+    let(:class_name) { 'Trogolodyte' }
+    subject(:is_label_for_table) { fixtures.send(:is_label_for_table?, label_to_check, table_name) }
+
+    context 'when it IS a label' do
+      let(:label_to_check) { 'trogolodytes_42' }
+      it 'is true' do
+        expect(is_label_for_table).to be true
+      end
+    end
+
+    context 'when it is NOT a label' do
+      let(:label_to_check) { '42' }
+      it 'is false' do
+        expect(is_label_for_table).to be false
+      end
+    end
+  end
+
   describe '#each_table_row_with_label' do
     subject(:yields) do
       [].tap do |yields|

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -93,6 +93,9 @@ describe LiveFixtures::Import::Fixtures do
     let(:cafe_label) { 'cafes_201300' }
 
     context "which use ERB" do
+      before do
+        allow(fixtures).to receive(:fetch_id_for_label) { 42 }
+      end
       let(:table_name) { "dogs" }
       let(:class_name) { Dog }
       let(:owner) { yields.find {|_, label, _| label == owner_label} }

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -15,10 +15,11 @@ describe LiveFixtures::Import::Fixtures do
       allow(ActiveRecord::FixtureSet).
         to receive(:new).
         with(any_args).
-        and_return(instance_double 'ActiveRecord::FixtureSet')
+        and_return(ar_fixtureset_double)
     end
-    let(:table_name) { nil }
-    let(:class_name) { nil }
+    let(:ar_fixtureset_double) { instance_double 'ActiveRecord::FixtureSet' }
+    let(:table_name) { 'trogolodytes' }
+    let(:class_name) { 'Trogolodyte' }
     subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
     let(:label_to_id) { { 'label' => 42 } }
 
@@ -30,6 +31,10 @@ describe LiveFixtures::Import::Fixtures do
     end
 
     context 'when the label is NOT in label_to_id' do
+      before do
+        allow(ar_fixtureset_double).to receive(:model_class) { class_name }
+        allow(ar_fixtureset_double).to receive(:table_name) { table_name }
+      end
       let(:label_to_fetch) { 'not_the_right_label' }
       it 'raises a MissingReferenceError' do
         expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -36,8 +36,16 @@ describe LiveFixtures::Import::Fixtures do
         allow(ar_fixtureset_double).to receive(:table_name) { table_name }
       end
       let(:label_to_fetch) { 'not_the_right_label' }
+      let(:expected_message) {
+        <<-ERROR.squish
+        Unable to find ID for model referenced by label not_the_right_label while
+        importing Trogolodyte from trogolodytes.yml. Perhaps it isn't included
+        in these fixtures or it is too late in the insert_order and has not yet
+        been imported.
+        ERROR
+      }
       it 'raises a MissingReferenceError' do
-        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError
+        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError, expected_message
       end
     end
   end

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -21,13 +21,20 @@ describe LiveFixtures::Import::Fixtures do
     let(:class_name) { nil }
     subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
     let(:label_to_id) { { 'label' => 42 } }
-    context 'when the label is in label_to_id' do
+
+    context 'when the label IS in label_to_id' do
       let(:label_to_fetch) { 'label' }
       it 'returns the corresponding id' do
         expect(fetch_id_for_label).to be 42
       end
     end
 
+    context 'when the label is NOT in label_to_id' do
+      let(:label_to_fetch) { 'not_the_right_label' }
+      it 'raises a MissingReferenceError' do
+        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError
+      end
+    end
   end
 
   describe '#each_table_row_with_label' do

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -78,6 +78,9 @@ describe LiveFixtures::Import::Fixtures do
   end
 
   describe '#each_table_row_with_label' do
+    before do
+      label_to_id.merge!(already_imported_labels)
+    end
     subject(:yields) do
       [].tap do |yields|
         fixtures.each_table_row_with_label do |table_name, label, row|
@@ -87,6 +90,7 @@ describe LiveFixtures::Import::Fixtures do
         end
       end
     end
+    let(:already_imported_labels) { {} }
     let(:owner_label) { 'dogs_2540939' }
     let(:visitor_one_label) { 'dogs_2540954' }
     let(:visitor_two_label) { 'dogs_2540956' }
@@ -118,7 +122,6 @@ describe LiveFixtures::Import::Fixtures do
     context "which have a has_and_belongs_to_many association of ids" do
       let(:table_name) { 'dogs' }
       let(:class_name) { 'Dog' }
-      let(:label_to_id) { {} }
       let(:join_table_name) { 'dogs_flavors' }
       let(:owner_join_table_rows) do
         yields.select do |table_name, _, row|
@@ -141,9 +144,8 @@ describe LiveFixtures::Import::Fixtures do
     context "which have a has_and_belongs_to_many association of labels" do
       let(:table_name) { "tables" }
       let(:class_name) { 'Table' }
-      let(:label_to_id) do
+      let(:already_imported_labels) do
         {
-            table_label => 1941,
             visitor_one_label => 1942,
             visitor_two_label => 1962,
             cafe_label => 2016
@@ -171,9 +173,10 @@ describe LiveFixtures::Import::Fixtures do
     context "which reference another fixture using a label" do
       let(:table_name) { "tables" }
       let(:class_name) { 'Table' }
-      let(:label_to_id) do
+      let(:already_imported_labels) do
         {
-            table_label => 1941,
+            visitor_one_label => 1942,
+            visitor_two_label => 1962,
             cafe_label => 2016
         }
       end
@@ -189,10 +192,11 @@ describe LiveFixtures::Import::Fixtures do
     context "which use STI and this subclass has an association the other classes don't" do
       let(:table_name) { "tables" }
       let(:class_name) { 'Table' }
-      let(:label_to_id) do
+      let(:already_imported_labels) do
         {
-            table_label => 1941,
-            cafe_label => 2016
+          visitor_one_label => 1942,
+          visitor_two_label => 1962,
+          cafe_label => 2016
         }
       end
       let(:low_table) { yields.find {|_, label, _| label == low_table_label} }

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -10,6 +10,26 @@ describe LiveFixtures::Import::Fixtures do
   let(:label_to_id) { {} }
   let(:filepath) { File.join(File.dirname(__FILE__), "../data/live_fixtures/dog_cafes/#{table_name}") }
 
+  describe '#fetch_id_for_label' do
+    before do
+      allow(ActiveRecord::FixtureSet).
+        to receive(:new).
+        with(any_args).
+        and_return(instance_double 'ActiveRecord::FixtureSet')
+    end
+    let(:table_name) { nil }
+    let(:class_name) { nil }
+    subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
+    let(:label_to_id) { { 'label' => 42 } }
+    context 'when the label is in label_to_id' do
+      let(:label_to_fetch) { 'label' }
+      it 'returns the corresponding id' do
+        expect(fetch_id_for_label).to be 42
+      end
+    end
+
+  end
+
   describe '#each_table_row_with_label' do
     subject(:yields) do
       [].tap do |yields|

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -80,8 +80,10 @@ describe LiveFixtures::Import::Fixtures do
   describe '#each_table_row_with_label' do
     subject(:yields) do
       [].tap do |yields|
-        fixtures.each_table_row_with_label do |value|
-          yields << value
+        fixtures.each_table_row_with_label do |table_name, label, row|
+          new_id = fake_db[label]
+          label_to_id[label] = new_id
+          yields << [table_name, label, row]
         end
       end
     end
@@ -91,11 +93,18 @@ describe LiveFixtures::Import::Fixtures do
     let(:table_label) { 'tables_977909' }
     let(:low_table_label) { 'tables_978319' }
     let(:cafe_label) { 'cafes_201300' }
+    let(:fake_db) {
+      {
+        owner_label => 1982,
+        visitor_one_label => 1942,
+        visitor_two_label => 1962,
+        table_label => 1941,
+        low_table_label => 1940,
+        cafe_label => 2016,
+      }
+    }
 
     context "which use ERB" do
-      before do
-        allow(fixtures).to receive(:fetch_id_for_label) { 42 }
-      end
       let(:table_name) { "dogs" }
       let(:class_name) { Dog }
       let(:owner) { yields.find {|_, label, _| label == owner_label} }
@@ -109,7 +118,7 @@ describe LiveFixtures::Import::Fixtures do
     context "which have a has_and_belongs_to_many association of ids" do
       let(:table_name) { 'dogs' }
       let(:class_name) { 'Dog' }
-      let(:label_to_id) { {owner_label => 1982} }
+      let(:label_to_id) { {} }
       let(:join_table_name) { 'dogs_flavors' }
       let(:owner_join_table_rows) do
         yields.select do |table_name, _, row|
@@ -136,7 +145,7 @@ describe LiveFixtures::Import::Fixtures do
         {
             table_label => 1941,
             visitor_one_label => 1942,
-            visitor_two_label => 1982,
+            visitor_two_label => 1962,
             cafe_label => 2016
         }
       end
@@ -155,7 +164,7 @@ describe LiveFixtures::Import::Fixtures do
         end
 
         habtm_ids = join_table_rows.map { |_, _, row| row['dog_id'].to_i}
-        expect(habtm_ids).to contain_exactly(1942, 1982)
+        expect(habtm_ids).to contain_exactly(1942, 1962)
       end
     end
 

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -19,8 +19,9 @@ describe LiveFixtures::Import do
       let(:insert_order) { %w{dogs cafes dog_cafes tables trogolodytes} }
       let(:root_path) { File.join(File.dirname(__FILE__), "data", "live_fixtures", "dog_cafes") }
       subject(:import) { LiveFixtures::Import.new root_path, insert_order }
-      it 'raises an ArgumentError' do
-        expect { import }.to raise_error ArgumentError
+      it 'ingores it' do
+        expect(import).to be_a LiveFixtures::Import
+        expect(import.instance_variable_get('@table_names')).not_to include 'trogolodytes'
       end
     end
   end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -14,6 +14,17 @@ describe LiveFixtures::Import do
     )
   end
 
+  describe '#initialize' do
+    context 'when insert_order includes a non-existent file' do
+      let(:insert_order) { %w{dogs cafes dog_cafes tables trogolodytes} }
+      let(:root_path) { File.join(File.dirname(__FILE__), "data", "live_fixtures", "dog_cafes") }
+      subject(:import) { LiveFixtures::Import.new root_path, insert_order }
+      it 'raises an ArgumentError' do
+        expect { import }.to raise_error ArgumentError
+      end
+    end
+  end
+
   it "creates records in the db as expected" do
     root_path = File.join File.dirname(__FILE__),
                           "data/live_fixtures/dog_cafes/"

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
 describe LiveFixtures::Import do
-  before do
-    allow(ProgressBar).to receive(:create).and_return(
-        double(ProgressBar, increment:nil, finished?: nil, finish: nil)
-    )
+  before(:all) do
     [2077, 2327, 2321, 1744].each do |id|
       Flavor.create do |rt|
         rt.id = id
       end
     end
+  end
+  before do
+    allow(ProgressBar).to receive(:create).and_return(
+        double(ProgressBar, increment:nil, finished?: nil, finish: nil)
+    )
   end
 
   it "creates records in the db as expected" do


### PR DESCRIPTION
#### Context:

When we instantiate a new `LiveFixtures::Import`, one of the arguments we must provide is an `insert_order`.

We use labels as placeholders for foreign_keys, so that records that are associated in the DB can continue to reference each other after being exported. On import, we replace these labels with the newly imported record's new ID, so the imported records will be properly associated again.

```YML
# In users.yml
users_1:
    posts: 'posts_1,posts_2'

# In posts.yml
posts_1:
    ...

posts_2:
    ...
```

The labels `users_1`, `posts_1`, and `posts_2` will be replaced with the fixture's new ID.

In order for this all to work properly, we have to import any fixture that is referenced BEFORE we try to import any fixture that references it. This way, when we import users from the example above, we'll have already imported posts and we'll know the IDs we should use to replace the labels `posts_1` and `posts_2`.

So, in the past we've been raising an error when we can't find one of the files listed in `insert_order`. This probably was meant to help keep us from forgetting to import posts.

This is a bit of a drag, because if we export a set of fixtures for one of users who doesn't have any posts, no posts.yml file will be generated, and the import will fail before it begins, even though the fixtures are valid.

Instead, we now raise a `LiveFixtures::MissingReferenceError` if we attempt to replace a label and cannot find a matching ID.

The error should help point you in the direction of what went wrong:

>Unable to find ID for model referenced by label not_the_right_label while importing Trogolodyte from trogolodytes.yml. Perhaps it isn't included in these fixtures or it is too late in the insert_order and has not yet been imported.

#### Github Issue:
Outfoxes: #13
 
 #### Merging this PR
 
 - [ ] Double check that all reviewers' comments were addressed or acknowledged.
    - Comments about future refactoring should end up as TODOs in the code.
 - [ ] **SQUASH** and Merge the PR.
 - [ ] Delete the branch.
