### PR TITLE
Strictness options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.1] - 2017-??-??
-### Fixed
+### Breaking changes
  - For models with serialized attributes (for storing a ruby object or json blob in a single column, for example), live_fixtures will now use the coder specified in the model definition to dump the value to a string, rather than serializing it to yaml. #10, #11
 
 ### Added
+- There is now an option to prevent the importer from raising an ArgumentError when a yml file for a table listed in `insert_order` cannot be found. Additionally there is an option to enable raising an error if we attempt to replace a label with an ID and cannot find the label yet. This should allow more versatile insert_order lists.
  - Enhanced documentation #1, #12
 
 ## [0.2.0] - 2017-05-09

--- a/README.md
+++ b/README.md
@@ -157,7 +157,21 @@ If we pass `:user` as references, LiveFixtures will replace the foreign key with
 
 When we import these fixtures using the correct `insert_order` (`['users', 'posts']`), the newly imported post will belong to the newly imported user, no matter what their new ids are.
 
-Currently, this only works for associations that return a single record (:belongs_to and :has_one).
+Currently, this works for `belongs_to` and `has_and_belongs_to_many` associations.
+
+For `has_and_belongs_to_many` associations, there is a good deal of flexibility. The attribute name should be the name of the association (probably plural). The attribute value should be a list of the associated records. This list can be either an array or a comma separated list. If the list is a list of labels, the labels will be replaced on import. If it is a list of IDs, the IDs will be inserted as they are listed.
+
+
+    # In dogwalkers.yml
+    dogwalkers_15:
+      dogs: '1,3'
+
+    dogwalkers_16:
+      dogs:
+        - dogs_12
+        - dogs_14
+
+The above fixture, when imported would add both Dogwalker fixtures to the `dogwalkers` table, and it would also populate the join table (`dogwalkers_dogs`, or whatever is specified by the association). All the labels will be replaced with their newly assigned IDs, but the IDs of dogwalkers_15's dogs will remain as 1 and 3.
 
 ### Templates
 

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -9,15 +9,16 @@ class LiveFixtures::Import
   # @raise [ArgumentError] raises an argument error if not every element in the insert_order has a corresponding yml file.
   # @param root_path [String] path to the directory containing the yml files to import.
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
+  # @param :skip_missing_tables [Boolean] whether to raise an ArgumentError if there isn't a yml file for each table in insert_order.
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
-  def initialize(root_path, insert_order)
+  def initialize(root_path, insert_order, skip_missing_tables: false)
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
       File.basename filepath, ".yml"
     end
     @table_names = insert_order.select {|table_name| @table_names.include? table_name}
-    if @table_names.size < insert_order.size
+    if @table_names.size < insert_order.size && !skip_missing_tables
       raise ArgumentError, "table(s) mentioned in `insert_order` which has no yml file to import: #{insert_order - @table_names}"
     end
     @label_to_id = {}

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -9,16 +9,18 @@ class LiveFixtures::Import
   # @raise [ArgumentError] raises an argument error if not every element in the insert_order has a corresponding yml file.
   # @param root_path [String] path to the directory containing the yml files to import.
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
-  # @param :skip_missing_tables [Boolean] whether to raise an ArgumentError if there isn't a yml file for each table in insert_order.
+  # @param [Hash] options the import options
+  # @option options [Boolean] :skip_missing_tables whether to raise an ArgumentError if there isn't a yml file for each table in insert_order.
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
-  def initialize(root_path, insert_order, skip_missing_tables: false)
+  def initialize(root_path, insert_order, **options)
+    @options = {skip_missing_tables: false}.merge(options)
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
       File.basename filepath, ".yml"
     end
     @table_names = insert_order.select {|table_name| @table_names.include? table_name}
-    if @table_names.size < insert_order.size && !skip_missing_tables
+    if @table_names.size < insert_order.size && @options[:skip_missing_tables] == false
       raise ArgumentError, "table(s) mentioned in `insert_order` which has no yml file to import: #{insert_order - @table_names}"
     end
     @label_to_id = {}

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -11,10 +11,11 @@ class LiveFixtures::Import
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
   # @param [Hash] options the import options
   # @option options [Boolean] :skip_missing_tables whether to raise an ArgumentError if there isn't a yml file for each table in insert_order.
+  # @option options [Boolean] :skip_missing_references whether to raise an error if an ID for a labeled reference cannot be found.
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
   def initialize(root_path, insert_order, **options)
-    @options = {skip_missing_tables: false}.merge(options)
+    @options = {skip_missing_tables: false, skip_missing_references: true}.merge(options)
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
       File.basename filepath, ".yml"
@@ -55,7 +56,8 @@ class LiveFixtures::Import
                             table_name,
                             class_name,
                             ::File.join(@root_path, path),
-                            @label_to_id)
+                            @label_to_id,
+                            skip_missing_references: @options[:skip_missing_references])
 
           conn = ff.model_connection || connection
           ProgressBarIterator.new(ff).each do |table_name, label, row|

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -77,6 +77,14 @@ class LiveFixtures::Import
 
     private
 
+    # Uses the underlying map of labels to return the referenced model's newly
+    # assigned ID.
+    # @param label_to_fetch [String] the label of the referenced model.
+    # @return [Integer] the newly assigned ID of the referenced model.
+    def fetch_id_for_label(label_to_fetch)
+      @label_to_id[label_to_fetch]
+    end
+
     def inheritance_column_name
       @inheritance_column_name ||= model_class && model_class.inheritance_column
     end

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -1,6 +1,7 @@
 require 'active_record/fixtures'
 
 class LiveFixtures::Import
+  LiveFixtures::MissingReferenceError = Class.new(KeyError)
   class Fixtures
     delegate :model_class, :table_name, :fixtures, to: :ar_fixtures
     # ActiveRecord::FixtureSet for delegation

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -1,6 +1,9 @@
 require 'active_record/fixtures'
 
 class LiveFixtures::Import
+  # A labeled reference was not found.
+  # Maybe the referenced model was not exported, or the insert order attempted
+  # to import the reference before the referenced model?
   LiveFixtures::MissingReferenceError = Class.new(KeyError)
   class Fixtures
     delegate :model_class, :table_name, :fixtures, to: :ar_fixtures

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -83,10 +83,18 @@ class LiveFixtures::Import
 
     # Uses the underlying map of labels to return the referenced model's newly
     # assigned ID.
+    # @raise [LiveFixtures::MissingReferenceError] if the label isn't found.
     # @param label_to_fetch [String] the label of the referenced model.
     # @return [Integer] the newly assigned ID of the referenced model.
     def fetch_id_for_label(label_to_fetch)
-      @label_to_id[label_to_fetch]
+      @label_to_id.fetch(label_to_fetch)
+    rescue KeyError
+      raise LiveFixtures::MissingReferenceError, <<-ERROR.squish
+      Unable to find ID for model referenced by label #{label_to_fetch} while
+      importing #{model_class} from #{table_name}.yml. Perhaps it isn't included
+      in these fixtures or it is too late in the insert_order and has not yet
+      been imported.
+      ERROR
     end
 
     def inheritance_column_name

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -127,7 +127,7 @@ class LiveFixtures::Import
         row[association.foreign_type] = $1
       end
 
-      row[fk_name] = @label_to_id[value]
+      row[fk_name] = fetch_id_for_label(value)
     end
 
     private :ar_fixtures

--- a/lib/live_fixtures/import/fixtures.rb
+++ b/lib/live_fixtures/import/fixtures.rb
@@ -69,7 +69,7 @@ class LiveFixtures::Import
         rows.each do |targets:, association:, label:|
           targets.each do |target|
             assoc_fk = @label_to_id[target] || target
-            row = { association.foreign_key             => @label_to_id[label],
+            row = { association.foreign_key             => fetch_id_for_label(label),
                     association.association_foreign_key => assoc_fk }
             yield [table_name, NO_LABEL, row]
           end

--- a/live_fixtures.gemspec
+++ b/live_fixtures.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "temping", "~> 3.0"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "reek"

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -10,46 +10,6 @@ describe LiveFixtures::Import::Fixtures do
   let(:label_to_id) { {} }
   let(:filepath) { File.join(File.dirname(__FILE__), "../data/live_fixtures/dog_cafes/#{table_name}") }
 
-  describe '#fetch_id_for_label' do
-    before do
-      allow(ActiveRecord::FixtureSet).
-        to receive(:new).
-        with(any_args).
-        and_return(ar_fixtureset_double)
-    end
-    let(:ar_fixtureset_double) { instance_double 'ActiveRecord::FixtureSet' }
-    let(:table_name) { 'trogolodytes' }
-    let(:class_name) { 'Trogolodyte' }
-    subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
-    let(:label_to_id) { { 'label' => 42 } }
-
-    context 'when the label IS in label_to_id' do
-      let(:label_to_fetch) { 'label' }
-      it 'returns the corresponding id' do
-        expect(fetch_id_for_label).to be 42
-      end
-    end
-
-    context 'when the label is NOT in label_to_id' do
-      before do
-        allow(ar_fixtureset_double).to receive(:model_class) { class_name }
-        allow(ar_fixtureset_double).to receive(:table_name) { table_name }
-      end
-      let(:label_to_fetch) { 'not_the_right_label' }
-      let(:expected_message) {
-        <<-ERROR.squish
-        Unable to find ID for model referenced by label not_the_right_label while
-        importing Trogolodyte from trogolodytes.yml. Perhaps it isn't included
-        in these fixtures or it is too late in the insert_order and has not yet
-        been imported.
-        ERROR
-      }
-      it 'raises a MissingReferenceError' do
-        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError, expected_message
-      end
-    end
-  end
-
   describe '#each_table_row_with_label' do
     subject(:yields) do
       [].tap do |yields|

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -15,10 +15,11 @@ describe LiveFixtures::Import::Fixtures do
       allow(ActiveRecord::FixtureSet).
         to receive(:new).
         with(any_args).
-        and_return(instance_double 'ActiveRecord::FixtureSet')
+        and_return(ar_fixtureset_double)
     end
-    let(:table_name) { nil }
-    let(:class_name) { nil }
+    let(:ar_fixtureset_double) { instance_double 'ActiveRecord::FixtureSet' }
+    let(:table_name) { 'trogolodytes' }
+    let(:class_name) { 'Trogolodyte' }
     subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
     let(:label_to_id) { { 'label' => 42 } }
 
@@ -30,6 +31,10 @@ describe LiveFixtures::Import::Fixtures do
     end
 
     context 'when the label is NOT in label_to_id' do
+      before do
+        allow(ar_fixtureset_double).to receive(:model_class) { class_name }
+        allow(ar_fixtureset_double).to receive(:table_name) { table_name }
+      end
       let(:label_to_fetch) { 'not_the_right_label' }
       it 'raises a MissingReferenceError' do
         expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -66,7 +66,8 @@ describe LiveFixtures::Import::Fixtures do
         {
             table_label => 1941,
             visitor_one_label => 1942,
-            visitor_two_label => 1982
+            visitor_two_label => 1982,
+            cafe_label => 2016
         }
       end
       let(:join_table_name) { 'dogs_tables' }

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -36,8 +36,16 @@ describe LiveFixtures::Import::Fixtures do
         allow(ar_fixtureset_double).to receive(:table_name) { table_name }
       end
       let(:label_to_fetch) { 'not_the_right_label' }
+      let(:expected_message) {
+        <<-ERROR.squish
+        Unable to find ID for model referenced by label not_the_right_label while
+        importing Trogolodyte from trogolodytes.yml. Perhaps it isn't included
+        in these fixtures or it is too late in the insert_order and has not yet
+        been imported.
+        ERROR
+      }
       it 'raises a MissingReferenceError' do
-        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError
+        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError, expected_message
       end
     end
   end

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -21,13 +21,20 @@ describe LiveFixtures::Import::Fixtures do
     let(:class_name) { nil }
     subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
     let(:label_to_id) { { 'label' => 42 } }
-    context 'when the label is in label_to_id' do
+
+    context 'when the label IS in label_to_id' do
       let(:label_to_fetch) { 'label' }
       it 'returns the corresponding id' do
         expect(fetch_id_for_label).to be 42
       end
     end
 
+    context 'when the label is NOT in label_to_id' do
+      let(:label_to_fetch) { 'not_the_right_label' }
+      it 'raises a MissingReferenceError' do
+        expect { fetch_id_for_label }.to raise_error LiveFixtures::MissingReferenceError
+      end
+    end
   end
 
   describe '#each_table_row_with_label' do

--- a/spec/import/fixtures_spec.rb
+++ b/spec/import/fixtures_spec.rb
@@ -10,6 +10,26 @@ describe LiveFixtures::Import::Fixtures do
   let(:label_to_id) { {} }
   let(:filepath) { File.join(File.dirname(__FILE__), "../data/live_fixtures/dog_cafes/#{table_name}") }
 
+  describe '#fetch_id_for_label' do
+    before do
+      allow(ActiveRecord::FixtureSet).
+        to receive(:new).
+        with(any_args).
+        and_return(instance_double 'ActiveRecord::FixtureSet')
+    end
+    let(:table_name) { nil }
+    let(:class_name) { nil }
+    subject(:fetch_id_for_label) { fixtures.send(:fetch_id_for_label, label_to_fetch) }
+    let(:label_to_id) { { 'label' => 42 } }
+    context 'when the label is in label_to_id' do
+      let(:label_to_fetch) { 'label' }
+      it 'returns the corresponding id' do
+        expect(fetch_id_for_label).to be 42
+      end
+    end
+
+  end
+
   describe '#each_table_row_with_label' do
     subject(:yields) do
       [].tap do |yields|

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -14,6 +14,17 @@ describe LiveFixtures::Import do
     )
   end
 
+  describe '#initialize' do
+    context 'when insert_order includes a non-existent file' do
+      let(:insert_order) { %w{dogs cafes dog_cafes tables trogolodytes} }
+      let(:root_path) { File.join(File.dirname(__FILE__), "data", "live_fixtures", "dog_cafes") }
+      subject(:import) { LiveFixtures::Import.new root_path, insert_order }
+      it 'raises an ArgumentError' do
+        expect { import }.to raise_error ArgumentError
+      end
+    end
+  end
+
   it "creates records in the db as expected" do
     root_path = File.join File.dirname(__FILE__),
                           "data/live_fixtures/dog_cafes/"

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -22,6 +22,15 @@ describe LiveFixtures::Import do
       it 'raises an ArgumentError' do
         expect { import }.to raise_error ArgumentError
       end
+      context 'and :skip_missing_tables is true' do
+        subject(:import) {
+          LiveFixtures::Import.new root_path, insert_order, skip_missing_tables: true
+        }
+        it 'skips missing tables.' do
+          expect(import.instance_variable_get('@table_names')).
+            to match_array(insert_order - %w{trogolodytes})
+        end
+      end
     end
   end
 

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
 describe LiveFixtures::Import do
-  before do
-    allow(ProgressBar).to receive(:create).and_return(
-        double(ProgressBar, increment:nil, finished?: nil, finish: nil)
-    )
+  before(:all) do
     [2077, 2327, 2321, 1744].each do |id|
       Flavor.create do |rt|
         rt.id = id
       end
     end
+  end
+  before do
+    allow(ProgressBar).to receive(:create).and_return(
+        double(ProgressBar, increment:nil, finished?: nil, finish: nil)
+    )
   end
 
   it "creates records in the db as expected" do


### PR DESCRIPTION
# Please squash the commits when merging

These are not good commits to have in the history, some commits are at broken places which will be very unhelpful in the future. Please squash into one commit.

#### Context:


#### Github Issue:
Outfoxes: #

#### PT Link

link here!

#### For QA/Review

**Does** require cross-browser testing.
**Does NOT** require cross-browser testing.

* Step One.
* [ ] Checkbox Two.

#### Screenshots

<details>
<summary>Before</summary>

![Boo!](https://img.buzzfeed.com/buzzfeed-static/static/2015-04/21/16/enhanced/webdr05/enhanced-31550-1429646952-7.jpg)

</details>

<details>
<summary>After</summary>

![Boo!](https://img.buzzfeed.com/buzzfeed-static/static/2015-04/21/16/enhanced/webdr05/enhanced-31550-1429646952-7.jpg)

</details>
   
#### For the Author

 - [ ] CI :green_heart:
     <details><summary>(2)</summary>
        &#9900; If the build failed due to a flaky test:<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; rerun the build until it passes. As a rule, we only merge passing builds.<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; <a href="Tagging-Flaky-Tests.md">tag</a> any previously undocumented flaky tests<br />
        &#9900; If it includes major spec changes, particularly Capybara specs, consider running it in a timer loop on Jenkins to ensure it doesn't introduces non-determinism to the test suite.<br />
     </details>
 - [ ] <a href="https://github.com/NoRedInk/wiki/blob/master/Our-GitHub-Process.md#qa">Prepare for QA</a>
     <details><summary>(3)</summary>
        &#9900; Tag any issues this PR resolves by writing "Outfoxes #XYZ". <a href="https://github.com/NoRedInk/wiki/blob/master/Outfoxing.md">Why?</a><br />
        &#9900; Write easy-to-follow QA instructions<br />
        &#9900; If there are visual changes: declare whether your change requires cross-browser testing.<br />
     </details>
 - [ ] Visual changes are approved if necessary
     <details><summary>(2)</summary>
        &#9900; Include screenshots.<br />
        &#9900; <code>@mention</code> interested parties to review the screenshot before code review.<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; NoRedInk/qa  (remove me from @mentions if it's for dev stuff)<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; NoRedInk/design (remove me from @mentions if it's for admin / content creation / dev stuff)<br />
     </details>
 - [ ] Prepare for review
     <details><summary>(2)</summary>
    If you paired on this PR, you may choose to merge without further review after completing the reviewer checklist. Otherwise, follow the steps below:<br />
        &#9900; Make a note if you _don't_ want the reviewer to merge the PR following review.<br />
        &#9900; Request a review if:<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; There is a specific person you would like to review your PR, since they have domain knowledge or expertise that you would find helpful<br />
        &nbsp;&nbsp;&nbsp;&nbsp;&#9642; The PR is in silo and is consequently not well understood by most members of the team. In that case, you must assign the silo's owner.<br />
          Otherwise, the next available engineer will review it.
     </details>
 
 
 #### For the Reviewer
 
 - [ ] Follows the PR author checklist 
 - [ ] I understand the code
     <details><summary>(2)</summary>
       &#9900; Run through the code path on your own computer.<br />
       &#9900; Read the entire PR. Ask for clarification on unclear parts and consider clarifying the code itself.<br />
     </details>
 - [ ] Code is understandable to a new person
     <details><summary>(3)</summary>
       &#9900; API documentation in <code>doc/api</code> is up to date.<br />
       &#9900; Has comments that explain the whys<br />
       &#9900; Follows our styleguides<br />
     </details>
 - [ ] Code is sufficiently tested
     <details><summary>(3)</summary>
       &#9900; Test coverage is sufficient<br />
       &#9900; For Capistrano process, test the branch with a reset/deploy to staging prior to merging.<br />
       &#9900; For OpsWorks changes, ensure staging can boot an offline instance cleanly.<br />
     </details>
 - [ ] Code is safe
     <details><summary>(4)</summary>
       &#9900; Edgecases are taken into account<br />
       &#9900; If there are any potential <a href="https://github.com/NoRedInk/wiki/blob/master/Slow-Migrations.md">Slow Migrations</a>, make sure that:<br />
      &nbsp;&nbsp;&nbsp;&nbsp;&#9642; they are in separate PRs so each can be run independently<br />
      &nbsp;&nbsp;&nbsp;&nbsp;&#9642; there is a deployment plan where the resulting code on prod will support the db schema both before and after the migration<br />
       &#9900; All 4xx server errors are gracefully handled.<br />
       &#9900; Critical errors are reported to Rollbar.<br />
     </details>
 - [ ] Code is performant
     <details><summary>(2)</summary>
       &#9900; No n+1 queries<br />
       &#9900; SQL queries have sufficient index coverage<br />
     </details>
 - [ ] Code is backwards compatible
     <details><summary>(5)</summary>
       &#9900; Data will remain consistent. don't forget that <code>updated_at</code> gets updated automatically by Rails.<br />
       &#9900; Retired routes are redirected.<br />
       &#9900; Resque jobs should not be allowed to change their <code>.perform</code> signature. Rather: create a new resque job and retire the old one post-deploy after the queue is empty.<br />
       &#9900; If migrations include dropping a column, modifying a column, or adding a non-nullable column, ensure the previously deployed model is prepared to handle both the previous schema and the new schema. See: <a href="https://blog.codeship.com/rails-migrations-zero-downtime/">rails migrations with zero downtime</a><br />
       &#9900; API changes support the existing API for at least one deploy (see: <a href="Operations-Best-Practices.md">operations best practices</a>).<br />
     </details>
 
 
 #### Merging this PR
 
 - [ ] Double check that all reviewers' comments were addressed or acknowledged.
    - Comments about future refactoring should end up as TODOs in the code.
 - [ ] **SQUASH** and Merge the PR.
 - [ ] Delete the branch.

#### For Deploy

- [ ] No slow migrations
- [ ] No changes to Resque job signatures
- [ ] No changes to dependencies.<br />
- [ ] Code is fully backward compatible (OK).
