### PR TITLE
Optionally specify strictness and suppress progress bar

### DIFF
--- a/lib/live_fixtures/export.rb
+++ b/lib/live_fixtures/export.rb
@@ -31,6 +31,7 @@ module LiveFixtures::Export
 
   # Specify the options to use when exporting your fixtures.
   # @param [Hash] opts export configuration options
+  # @option opts [Boolean] show_progress whether or not to show the progress bar
   def set_export_options(**opts)
     defaults = { show_progress: true }
     @export_options = defaults.merge(opts)

--- a/lib/live_fixtures/export.rb
+++ b/lib/live_fixtures/export.rb
@@ -29,6 +29,12 @@ module LiveFixtures::Export
     FileUtils.mkdir_p(@dir) unless File.directory?(@dir)
   end
 
+  # Specify the options to use when exporting your fixtures.
+  # @param [Hash] opts export configuration options
+  def set_export_options(**opts)
+    @export_options = opts
+  end
+
   ##
   # Export models to a yml file named after the corresponding table.
   # @param models [Enumerable] an Enumerable containing ActiveRecord models.

--- a/lib/live_fixtures/export.rb
+++ b/lib/live_fixtures/export.rb
@@ -32,7 +32,14 @@ module LiveFixtures::Export
   # Specify the options to use when exporting your fixtures.
   # @param [Hash] opts export configuration options
   def set_export_options(**opts)
-    @export_options = opts
+    defaults = { show_progress: true }
+    @export_options = defaults.merge(opts)
+  end
+
+  # The options to use when exporting your fixtures.
+  # @return [Hash] export configuration options
+  def export_options
+    @export_options ||= set_export_options
   end
 
   ##
@@ -52,7 +59,9 @@ module LiveFixtures::Export
     table_name = models.first.class.table_name
     File.open(File.join(@dir, table_name + '.yml'), 'w') do |file|
 
-      ProgressBarIterator.new(models).each do |model|
+      iterator = export_options[:show_progress] ? ProgressBarIterator : SimpleIterator
+
+      iterator.new(models).each do |model|
         more_attributes = block_given? ? yield(model) : {}
         file.write Fixture.to_yaml(model, with_references, more_attributes)
       end
@@ -73,6 +82,19 @@ module LiveFixtures::Export
       @models.each do |model|
         yield model
         @bar.increment
+      end
+    end
+  end
+
+  class SimpleIterator
+    def initialize(models)
+      @models = models
+    end
+
+    def each
+      puts @models.first.class.name
+      @models.each do |model|
+        yield model
       end
     end
   end

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -13,14 +13,14 @@ class LiveFixtures::Import
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
   def initialize(root_path, insert_order, **opts)
-    defaut_options = { show_progress: true }
+    defaut_options = { show_progress: true, skip_missing_tables: false }
     @options = defaut_options.merge(opts)
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
       File.basename filepath, ".yml"
     end
     @table_names = insert_order.select {|table_name| @table_names.include? table_name}
-    if @table_names.size < insert_order.size
+    if @table_names.size < insert_order.size && !@options[:skip_missing_tables]
       raise ArgumentError, "table(s) mentioned in `insert_order` which has no yml file to import: #{insert_order - @table_names}"
     end
     @label_to_id = {}

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -13,7 +13,7 @@ class LiveFixtures::Import
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
   def initialize(root_path, insert_order, **opts)
-    defaut_options = { show_progress: true, skip_missing_tables: false }
+    defaut_options = { show_progress: true, skip_missing_tables: false, skip_missing_refs: true }
     @options = defaut_options.merge(opts)
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
@@ -55,7 +55,8 @@ class LiveFixtures::Import
                             table_name,
                             class_name,
                             ::File.join(@root_path, path),
-                            @label_to_id)
+                            @label_to_id,
+                            skip_missing_refs: @options[:skip_missing_refs])
 
           conn = ff.model_connection || connection
           iterator = @options[:show_progress] ? ProgressBarIterator : SimpleIterator

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -9,9 +9,11 @@ class LiveFixtures::Import
   # @raise [ArgumentError] raises an argument error if not every element in the insert_order has a corresponding yml file.
   # @param root_path [String] path to the directory containing the yml files to import.
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
+  # @param [Hash] opts export configuration options
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
-  def initialize(root_path, insert_order)
+  def initialize(root_path, insert_order, **opts)
+    @options = opts
     @root_path = root_path
     @table_names = Dir.glob(File.join(@root_path, '{*,**}/*.yml')).map do |filepath|
       File.basename filepath, ".yml"

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -10,6 +10,9 @@ class LiveFixtures::Import
   # @param root_path [String] path to the directory containing the yml files to import.
   # @param insert_order [Array<String>] a list of yml files (without .yml extension) in the order they should be imported.
   # @param [Hash] opts export configuration options
+  # @option opts [Boolean] show_progress whether or not to show the progress bar
+  # @option opts [Boolean] skip_missing_tables when false, an error will be raised if a yaml file isn't found for each table in insert_order
+  # @option opts [Boolean] skip_missing_refs when false, an error will be raised if an ID isn't found for a label.
   # @return [LiveFixtures::Import] an importer
   # @see LiveFixtures::Export::Reference
   def initialize(root_path, insert_order, **opts)


### PR DESCRIPTION
#### Context:

When we instantiate a new `LiveFixtures::Import`, one of the arguments we must provide is an `insert_order`.

We use labels as placeholders for foreign_keys, so that records that are associated in the DB can continue to reference each other after being exported. On import, we replace these labels with the newly imported record's new ID, so the imported records will be properly associated again.

```YML
# In users.yml
users_1:
    posts: 'posts_1,posts_2'

# In posts.yml
posts_1:
    ...

posts_2:
    ...
```

The labels `users_1`, `posts_1`, and `posts_2` will be replaced with the fixture's new ID.

In order for this all to work properly, we have to import any fixture that is referenced BEFORE we try to import any fixture that references it. This way, when we import users from the example above, we'll have already imported posts and we'll know the IDs we should use to replace the labels `posts_1` and `posts_2`.

So, in the past we've been raising an error when we can't find one of the files listed in `insert_order`. This probably was meant to help keep us from forgetting to import posts.

This is a bit of a drag, because if we export a set of fixtures for one of users who doesn't have any posts, no posts.yml file will be generated, and the import will fail before it begins, even though the fixtures are valid.

Instead, we now raise a `LiveFixtures::MissingReferenceError` if we attempt to replace a label and cannot find a matching ID.

The error should help point you in the direction of what went wrong:

>Unable to find ID for model referenced by label not_the_right_label while importing Trogolodyte from trogolodytes.yml. Perhaps it isn't included in these fixtures or it is too late in the insert_order and has not yet been imported.

#### Github Issue:
Outfoxes: #13

Outfoxes: #3

This PR adds a simple iterator that just puts what would have been the title of the bar, and then yields each item.
 
 #### Merging this PR
 
 - [ ] Double check that all reviewers' comments were addressed or acknowledged.
    - Comments about future refactoring should end up as TODOs in the code.
 - [ ] **SQUASH** and Merge the PR.
 - [ ] Delete the branch.
