### PR TITLE
Allow intentional export of id

### DIFF
--- a/lib/live_fixtures/export/fixture.rb
+++ b/lib/live_fixtures/export/fixture.rb
@@ -36,8 +36,7 @@ module LiveFixtures::Export::Fixture
   end
 
   private_class_method def yml_attributes(model, more_attributes)
-    model.attributes.merge(more_attributes).map do |name, value|
-      next if %w{id}.include? name
+    model.attributes.except("id").merge(more_attributes).map do |name, value|
       next if value.nil?
 
       serialize_attribute(model, name, value)

--- a/spec/export/fixture_spec.rb
+++ b/spec/export/fixture_spec.rb
@@ -153,6 +153,14 @@ describe LiveFixtures::Export::Fixture do
             expect(yaml).to     match /key: "rainbows"/
           end
         end
+
+        context "that include model.id" do
+          let(:more_attributes) { {'id' => model.id} }
+          it "includes the model's id" do
+            expect(yaml).to match /key: "butts"/
+            expect(yaml).to match /id: #{model.id}/
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Outfoxes #19 

In some rare cases, we might want to export a record's literal id into the fixtures' yaml file.

Currently this isn't possible, because we prevent exporting the id.

This PR makes it possible to explicitly export the id by including it along with the `more_attributes`.

Default behavior doesn't change.