### PR TITLE
Call private last_inserted_id method

### DIFF
--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -65,7 +65,7 @@ class LiveFixtures::Import
           iterator = @options[:show_progress] ? ProgressBarIterator : SimpleIterator
           iterator.new(ff).each do |table_name, label, row|
             conn.insert_fixture(row, table_name)
-            @label_to_id[label] = conn.last_inserted_id(table_name) unless label == NO_LABEL
+            @label_to_id[label] = conn.send(:last_inserted_id, table_name) unless label == NO_LABEL
           end
         end
       end


### PR DESCRIPTION
`last_inserted_id` has been made private in Rails 5. The contents of `import_all` are already a patch of sorts, and `last_inserted_id` was previously protected, so doing it this way seems okay to me.