### PR TITLE
[Experiment] Infer `insert_order` from model associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `LiveFixtures::Export` module is meant to be included into your export class
 
 ### Importing
 
-The `LiveFixtures::Import` class allows you to specify the location of your fixtures and the order in which to import them. Once you've done that, you can import them directly to your database.
+The `LiveFixtures::Import` class allows you to specify the location of your fixtures and, optionally, the order in which to import them. If you don't specify an order, the order will be computed from the ActiveRecord models associations. Once you've done that, you can import them directly to your database.
 
 
     module Seed::User

--- a/lib/live_fixtures.rb
+++ b/lib/live_fixtures.rb
@@ -1,6 +1,7 @@
 require "live_fixtures/version"
 require "live_fixtures/import"
 require "live_fixtures/import/fixtures"
+require "live_fixtures/import/insertion_order_computer"
 require "live_fixtures/export"
 require "live_fixtures/export/fixture"
 require "ruby-progressbar"

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -1,0 +1,112 @@
+class LiveFixtures::Import
+  # :nodoc:
+  class InsertionOrderComputer
+    # :nodoc:
+    class Node
+      attr_reader :path
+      attr_reader :class_name
+      attr_reader :klass
+
+      # The classes this node depends on
+      attr_reader :dependencies
+
+      def initialize(path, class_name, klass)
+        @path = path
+        @class_name = class_name
+        @klass = klass
+        @dependencies = Set.new
+      end
+    end
+
+    def self.compute(table_names)
+      new(table_names).compute
+    end
+
+    def initialize(table_names)
+      @table_names = table_names
+    end
+
+    def compute
+      nodes = build_nodes
+      compute_insert_order(nodes)
+    end
+
+    private
+
+    # Builds an Array of Nodes, each containing dependencies to other nodes
+    # using their class names.
+    def build_nodes
+      class_names = {}
+      @table_names.each { |n|
+        class_names[n.tr("/", "_").to_sym] ||= n.classify if n.include?("/")
+      }
+
+      # Create a Hash[Class => Node] for each table/class
+      nodes = Hash[@table_names.map do |path|
+                     table_name = path.tr "/", "_"
+                     class_name = class_names[table_name.to_sym] || table_name.classify
+                     klass = class_name.constantize
+
+                     [klass, Node.new(path, class_name, klass)]
+                   end]
+
+      # Compute dependencies between nodes/classes by reflecting on their
+      # ActiveRecord associations.
+      nodes.each do |_, node|
+        klass = node.klass
+        klass.reflect_on_all_associations.each do |assoc|
+          case assoc.macro
+          when :belongs_to
+            node.dependencies << assoc.klass
+          when :has_one
+            # Skip through association becuase it will be already computed
+            # for the related `has_one` association
+            next if assoc.options[:through]
+
+            nodes[assoc.klass].dependencies << klass
+          when :has_many
+            # Skip through association becuase it will be already computed
+            # for the related `has_many` association
+            next if assoc.options[:through]
+
+            nodes[assoc.klass].dependencies << klass
+          end
+        end
+      end
+
+      # Finally sort all values by name for consistent results
+      nodes.values.sort_by { |node| node.klass.name }
+    end
+
+    def compute_insert_order(nodes)
+      insert_order = []
+
+      until nodes.empty?
+        # Pick a node that has no dependencies
+        free_node = nodes.find { |node| node.dependencies.empty? }
+
+        if free_node.nil?
+          msg = "Can't compute an insert order.\n\n"
+          msg << "These models seem to depend on each other:\n"
+          nodes.each do |node|
+            msg << "  #{node.klass.name}\n"
+            msg << "   - depends on: #{node.dependencies.map(&:name).join(", ")}\n"
+          end
+          raise msg
+        end
+
+        insert_order << free_node.path
+
+        # Delete this node from the other nodes' dependencies
+        nodes.each do |node|
+          node.dependencies.delete(free_node.klass)
+        end
+
+        # And delete this node because we are done with it
+        nodes.delete(free_node)
+      end
+
+      insert_order
+    end
+  end
+end

--- a/spec/import/insertion_order_computer_spec.rb
+++ b/spec/import/insertion_order_computer_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe LiveFixtures::Import::InsertionOrderComputer do
+  it "computes for belongs_to" do
+    Temping.create :authors do
+      with_columns do |t|
+        t.string :name
+      end
+    end
+
+    Temping.create :books do
+      with_columns do |t|
+        t.integer :author_id
+        t.string :name
+      end
+
+      belongs_to :author
+    end
+
+    tables = %w{books authors}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{authors books})
+    end
+  end
+
+  it "computes for has_one" do
+    Temping.create :supplier do
+      with_columns do |t|
+        t.string :name
+      end
+
+      has_one :account
+    end
+
+    Temping.create :account do
+      with_columns do |t|
+        t.integer :supplier_id
+        t.string :account_number
+      end
+    end
+
+    tables = %w{account supplier}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{supplier account})
+    end
+  end
+
+  it "computes for has_many" do
+    Temping.create :xauthors do
+      with_columns do |t|
+        t.string :name
+      end
+
+      has_many :xbooks
+    end
+
+    Temping.create :xbooks do
+      with_columns do |t|
+        t.integer :xauthor_id
+        t.string :name
+      end
+    end
+
+    tables = %w{xbooks xauthors}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{xauthors xbooks})
+    end
+  end
+end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -5,6 +5,8 @@ describe LiveFixtures::Import do
     allow(ProgressBar).to receive(:create).and_return(
         double(ProgressBar, increment:nil, finished?: nil, finish: nil)
     )
+
+    Flavor.delete_all
     [2077, 2327, 2321, 1744].each do |id|
       Flavor.create do |rt|
         rt.id = id
@@ -16,8 +18,10 @@ describe LiveFixtures::Import do
     root_path = File.join File.dirname(__FILE__),
                           "data/live_fixtures/dog_cafes/"
 
-    importer = LiveFixtures::Import.new root_path,
-      %w{dogs cafes dog_cafes tables}
+    insert_order = %w{dogs cafes dog_cafes tables}
+    importer = LiveFixtures::Import.new root_path, insert_order
+
+    expect(importer.insert_order).to eq(insert_order)
 
     expect { importer.import_all }.
       to  change { Dog.count }.by(3).
@@ -59,6 +63,15 @@ describe LiveFixtures::Import do
 
     expect( visitors.flat_map(&:flavors).map(&:id) ).
         to contain_exactly(2321, 2077, 1744)
+  end
+
+  it "computes insert order if non is specified" do
+    root_path = File.join File.dirname(__FILE__),
+                          "data/live_fixtures/dog_cafes/"
+
+    importer = LiveFixtures::Import.new root_path
+
+    expect(importer.insert_order).to eq(%w{dogs cafes dog_cafes tables})
   end
 end
 


### PR DESCRIPTION
The `insert_order` attribute can be computed from the underlying ActiveRecord model associations. This commit computes a graph of dependencies between the models and computes the insert order, starting
from models that don't depend on others and so on.