### PR TITLE
Infer import order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache: bundler
 before_install:
   - gem update --system
   - gem install bundler
+services:
+  - mysql
 env:
   - DB=sqlite
   - DB=mysql

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `LiveFixtures::Export` module is meant to be included into your export class
 
 ### Importing
 
-The `LiveFixtures::Import` class allows you to specify the location of your fixtures and the order in which to import them. Once you've done that, you can import them directly to your database.
+The `LiveFixtures::Import` class allows you to specify the location of your fixtures and, optionally, the order in which to import them. If you don't specify an order, the order will be computed from the ActiveRecord models associations. Once you've done that, you can import them directly to your database.
 
 
     module Seed::User

--- a/lib/live_fixtures.rb
+++ b/lib/live_fixtures.rb
@@ -5,6 +5,7 @@ require "live_fixtures/import/insertion_order_computer"
 require "live_fixtures/export"
 require "live_fixtures/export/fixture"
 require "ruby-progressbar"
+require "yaml"
 
 module LiveFixtures
   module_function

--- a/lib/live_fixtures.rb
+++ b/lib/live_fixtures.rb
@@ -1,6 +1,7 @@
 require "live_fixtures/version"
 require "live_fixtures/import"
 require "live_fixtures/import/fixtures"
+require "live_fixtures/import/insertion_order_computer"
 require "live_fixtures/export"
 require "live_fixtures/export/fixture"
 require "ruby-progressbar"

--- a/lib/live_fixtures/import.rb
+++ b/lib/live_fixtures/import.rb
@@ -34,9 +34,7 @@ class LiveFixtures::Import
     }
 
     @insert_order = insert_order
-    if @insert_order.nil?
-      @insert_order = InsertionOrderComputer.compute(@table_names, @class_names, compute_polymorphic_associations)
-    end
+    @insert_order ||= InsertionOrderComputer.compute(@table_names, @class_names, compute_polymorphic_associations)
 
     @table_names = @insert_order.select {|table_name| @table_names.include? table_name}
     if @table_names.size < @insert_order.size && !@options[:skip_missing_tables]

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -54,6 +54,11 @@ class LiveFixtures::Import
           # Don't add a dependency if the class is not in the given table names
           next unless nodes.key?(assoc.klass)
 
+          # A class might depend on itself, but we don't add it as a dependency
+          # because otherwise we'll never make it (the class can probably be created
+          # just fine and these dependencies are optional/nilable)
+          next if klass == assoc.klass
+
           case assoc.macro
           when :belongs_to
             node.dependencies << assoc.klass

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -39,13 +39,13 @@ class LiveFixtures::Import
     # using their class names.
     def build_nodes
       # Create a Hash[Class => Node] for each table/class
-      nodes = Hash[@table_names.map do |path|
-                     table_name = path.tr "/", "_"
-                     class_name = @class_names[table_name.to_sym] || table_name.classify
-                     klass = class_name.constantize
-
-                     [klass, Node.new(path, class_name, klass)]
-                   end]
+      nodes = {}
+      @table_names.each do |path|
+        table_name = path.tr "/", "_"
+        class_name = @class_names[table_name.to_sym] || table_name.classify
+        klass = class_name.constantize
+        nodes[klass] = Node.new(path, class_name, klass)
+      end
 
       # First iniitalize dependencies from polymorphic associations that we
       # explicitly found in the yaml files.

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -18,12 +18,13 @@ class LiveFixtures::Import
       end
     end
 
-    def self.compute(table_names)
-      new(table_names).compute
+    def self.compute(table_names, class_names = {})
+      new(table_names, class_names).compute
     end
 
-    def initialize(table_names)
+    def initialize(table_names, class_names = {})
       @table_names = table_names
+      @class_names = class_names
     end
 
     def compute
@@ -36,15 +37,10 @@ class LiveFixtures::Import
     # Builds an Array of Nodes, each containing dependencies to other nodes
     # using their class names.
     def build_nodes
-      class_names = {}
-      @table_names.each { |n|
-        class_names[n.tr("/", "_").to_sym] ||= n.classify if n.include?("/")
-      }
-
       # Create a Hash[Class => Node] for each table/class
       nodes = Hash[@table_names.map do |path|
                      table_name = path.tr "/", "_"
-                     class_name = class_names[table_name.to_sym] || table_name.classify
+                     class_name = @class_names[table_name.to_sym] || table_name.classify
                      klass = class_name.constantize
 
                      [klass, Node.new(path, class_name, klass)]

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -1,0 +1,112 @@
+class LiveFixtures::Import
+  # :nodoc:
+  class InsertionOrderComputer
+    # :nodoc:
+    class Node
+      attr_reader :path
+      attr_reader :class_name
+      attr_reader :klass
+
+      # The classes this node depends on
+      attr_reader :dependencies
+
+      def initialize(path, class_name, klass)
+        @path = path
+        @class_name = class_name
+        @klass = klass
+        @dependencies = Set.new
+      end
+    end
+
+    def self.compute(table_names)
+      new(table_names).compute
+    end
+
+    def initialize(table_names)
+      @table_names = table_names
+    end
+
+    def compute
+      nodes = build_nodes
+      compute_insert_order(nodes)
+    end
+
+    private
+
+    # Builds an Array of Nodes, each containing dependencies to other nodes
+    # using their class names.
+    def build_nodes
+      class_names = {}
+      @table_names.each { |n|
+        class_names[n.tr("/", "_").to_sym] ||= n.classify if n.include?("/")
+      }
+
+      # Create a Hash[Class => Node] for each table/class
+      nodes = Hash[@table_names.map do |path|
+                     table_name = path.tr "/", "_"
+                     class_name = class_names[table_name.to_sym] || table_name.classify
+                     klass = class_name.constantize
+
+                     [klass, Node.new(path, class_name, klass)]
+                   end]
+
+      # Compute dependencies between nodes/classes by reflecting on their
+      # ActiveRecord associations.
+      nodes.each do |_, node|
+        klass = node.klass
+        klass.reflect_on_all_associations.each do |assoc|
+          case assoc.macro
+          when :belongs_to
+            node.dependencies << assoc.klass
+          when :has_one
+            # Skip through association becuase it will be already computed
+            # for the related `has_one` association
+            next if assoc.options[:through]
+
+            nodes[assoc.klass].dependencies << klass
+          when :has_many
+            # Skip through association becuase it will be already computed
+            # for the related `has_many` association
+            next if assoc.options[:through]
+
+            nodes[assoc.klass].dependencies << klass
+          end
+        end
+      end
+
+      # Finally sort all values by name for consistent results
+      nodes.values.sort_by { |node| node.klass.name }
+    end
+
+    def compute_insert_order(nodes)
+      insert_order = []
+
+      until nodes.empty?
+        # Pick a node that has no dependencies
+        free_node = nodes.find { |node| node.dependencies.empty? }
+
+        if free_node.nil?
+          msg = "Can't compute an insert order.\n\n"
+          msg << "These models seem to depend on each other:\n"
+          nodes.each do |node|
+            msg << "  #{node.klass.name}\n"
+            msg << "   - depends on: #{node.dependencies.map(&:name).join(", ")}\n"
+          end
+          raise msg
+        end
+
+        insert_order << free_node.path
+
+        # Delete this node from the other nodes' dependencies
+        nodes.each do |node|
+          node.dependencies.delete(free_node.klass)
+        end
+
+        # And delete this node because we are done with it
+        nodes.delete(free_node)
+      end
+
+      insert_order
+    end
+  end
+end

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -54,15 +54,9 @@ class LiveFixtures::Import
           case assoc.macro
           when :belongs_to
             node.dependencies << assoc.klass
-          when :has_one
-            # Skip through association becuase it will be already computed
-            # for the related `has_one` association
-            next if assoc.options[:through]
-
-            nodes[assoc.klass].dependencies << klass
-          when :has_many
-            # Skip through association becuase it will be already computed
-            # for the related `has_many` association
+          when :has_one, :has_many
+            # Skip `through` association becuase it will be already computed
+            # for the related `has_one`/`has_many` association
             next if assoc.options[:through]
 
             nodes[assoc.klass].dependencies << klass

--- a/lib/live_fixtures/import/insertion_order_computer.rb
+++ b/lib/live_fixtures/import/insertion_order_computer.rb
@@ -51,6 +51,9 @@ class LiveFixtures::Import
       nodes.each do |_, node|
         klass = node.klass
         klass.reflect_on_all_associations.each do |assoc|
+          # Don't add a dependency if the class is not in the given table names
+          next unless nodes.key?(assoc.klass)
+
           case assoc.macro
           when :belongs_to
             node.dependencies << assoc.klass

--- a/spec/import/insertion_order_computer_spec.rb
+++ b/spec/import/insertion_order_computer_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe LiveFixtures::Import::InsertionOrderComputer do
+  it "computes for belongs_to" do
+    Temping.create :authors do
+      with_columns do |t|
+        t.string :name
+      end
+    end
+
+    Temping.create :books do
+      with_columns do |t|
+        t.integer :author_id
+        t.string :name
+      end
+
+      belongs_to :author
+    end
+
+    tables = %w{books authors}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{authors books})
+    end
+  end
+
+  it "computes for has_one" do
+    Temping.create :supplier do
+      with_columns do |t|
+        t.string :name
+      end
+
+      has_one :account
+    end
+
+    Temping.create :account do
+      with_columns do |t|
+        t.integer :supplier_id
+        t.string :account_number
+      end
+    end
+
+    tables = %w{account supplier}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{supplier account})
+    end
+  end
+
+  it "computes for has_many" do
+    Temping.create :xauthors do
+      with_columns do |t|
+        t.string :name
+      end
+
+      has_many :xbooks
+    end
+
+    Temping.create :xbooks do
+      with_columns do |t|
+        t.integer :xauthor_id
+        t.string :name
+      end
+    end
+
+    tables = %w{xbooks xauthors}
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation)
+      expect(insert_order).to eq(%w{xauthors xbooks})
+    end
+  end
+end

--- a/spec/import/insertion_order_computer_spec.rb
+++ b/spec/import/insertion_order_computer_spec.rb
@@ -69,4 +69,29 @@ describe LiveFixtures::Import::InsertionOrderComputer do
       expect(insert_order).to eq(%w{xauthors xbooks})
     end
   end
+
+  it "computes for has_many with renamed tables" do
+    Temping.create :xyauthors do
+      with_columns do |t|
+        t.string :name
+      end
+
+      has_many :xybooks
+    end
+
+    Temping.create :xybooks do
+      with_columns do |t|
+        t.integer :xyauthor_id
+        t.string :name
+      end
+    end
+
+    tables = %w{books authors}
+    class_names = {books: "Xybook", authors: "Xyauthor"}
+
+    tables.permutation.each do |permutation|
+      insert_order = LiveFixtures::Import::InsertionOrderComputer.compute(permutation, class_names)
+      expect(insert_order).to eq(%w{authors books})
+    end
+  end
 end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -5,6 +5,8 @@ describe LiveFixtures::Import do
     allow(ProgressBar).to receive(:create).and_return(
         double(ProgressBar, increment:nil, finished?: nil, finish: nil)
     )
+
+    Flavor.delete_all
     [2077, 2327, 2321, 1744].each do |id|
       Flavor.create do |rt|
         rt.id = id
@@ -16,8 +18,10 @@ describe LiveFixtures::Import do
     root_path = File.join File.dirname(__FILE__),
                           "data/live_fixtures/dog_cafes/"
 
-    importer = LiveFixtures::Import.new root_path,
-      %w{dogs cafes dog_cafes tables}
+    insert_order = %w{dogs cafes dog_cafes tables}
+    importer = LiveFixtures::Import.new root_path, insert_order
+
+    expect(importer.insert_order).to eq(insert_order)
 
     expect { importer.import_all }.
       to  change { Dog.count }.by(3).
@@ -59,6 +63,15 @@ describe LiveFixtures::Import do
 
     expect( visitors.flat_map(&:flavors).map(&:id) ).
         to contain_exactly(2321, 2077, 1744)
+  end
+
+  it "computes insert order if non is specified" do
+    root_path = File.join File.dirname(__FILE__),
+                          "data/live_fixtures/dog_cafes/"
+
+    importer = LiveFixtures::Import.new root_path
+
+    expect(importer.insert_order).to eq(%w{dogs cafes dog_cafes tables})
   end
 end
 


### PR DESCRIPTION
Revival of #31

This is a **breaking-change** in the API.

The idea of this PR is to automatically compute the `insert_order` instead of users having to specify it. Manually specifying it involves running the importer and waiting until at some point you get an error saying you need to fix the `insert_order`. You try to fix it, try again, wait, etc. With this PR things will work well without having to fiddle with `insert_order`.

## How it works

The main idea is that, given the tables that we deduce from the `yml` fixture files, we reflect on ActiveRecord associations to know which types depend on which others. For example a Course might have Users, which means `User` should come first in the `insert_order`.

This basic idea is fine as a start but it's actually more complex: some tables have polymorphic associations and ActiveRecord can't tell you which types are in that association. To figure them out we inspec the `yml` fixture files and check fields that end with `_type` which should include the class name of the polymorphic association. With that we are able to compute some more dependencies.

## Breaking change

This is a breaking change because `LiveFixtures::Import.new` now needs to receive the `class_names` Hash to be able to correctly compute the `insert_order` in case there are some unconventional class names associations. And the `class_names` argument is removed from `import_all`. But this is the only change.