### PR TITLE
Add option to skip attributes during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.0] - 2024-04-04
+### Added
+It's now possible to specify a list of attributes to skip while exporting.
+
 ## [3.0.0] - 2023-07-24
 ### Added
 support ruby >= 3.1

--- a/lib/live_fixtures/version.rb
+++ b/lib/live_fixtures/version.rb
@@ -1,3 +1,3 @@
 module LiveFixtures
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/spec/export/fixture_spec.rb
+++ b/spec/export/fixture_spec.rb
@@ -6,7 +6,8 @@ describe LiveFixtures::Export::Fixture do
     let(:yaml) {
       LiveFixtures::Export::Fixture.to_yaml(model,
                                             references,
-                                            more_attributes)
+                                            more_attributes,
+                                            skip_attributes: skip_attributes)
     }
     let(:model) { new_model(table_name, attributes) }
     let(:table_name) { 'tables' }
@@ -14,6 +15,7 @@ describe LiveFixtures::Export::Fixture do
     let(:type_for_attribute) { instance_double('ActiveRecord::Type') }
     let(:references) { [] }
     let(:more_attributes) { {} }
+    let(:skip_attributes) { [] }
 
     def new_model(table_name, attributes={})
       double('Model',
@@ -160,6 +162,13 @@ describe LiveFixtures::Export::Fixture do
             expect(yaml).to match /key: "butts"/
             expect(yaml).to match /id: #{model.id}/
           end
+        end
+      end
+
+      context "when skip_attributes are specified" do
+        let(:skip_attributes) { ['key'] }
+        it "does not include them" do
+          expect(yaml).to_not match /key: "butts"/
         end
       end
     end


### PR DESCRIPTION
Add a parameter to `Export::Fixture.to_yaml` to skip certain attributes from being serialized.